### PR TITLE
Salt node config was ignoring the npm dependency

### DIFF
--- a/node/init.sls
+++ b/node/init.sls
@@ -20,6 +20,9 @@ installnode:
     - watch:
       - file: {{pillar['saltbin']}}/nodeinstall
 
+npm:
+  pkg.installed
+
 # node supervisor
 nodesupervisor:
   npm.installed:


### PR DESCRIPTION
According to the Salt documentation
http://docs.saltstack.com/en/latest/ref/states/all/salt.states.npm.html

npm must be installed in order to use the npm.installed state manager.
node/init.sls was not setting npm to be installed.
